### PR TITLE
Updating from factory girl to factory bot

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -41,7 +41,7 @@ group :development, :test do
   gem 'selenium-webdriver'
   gem 'better_errors'
   gem 'binding_of_caller'
-  gem 'factory_girl_rails'
+  gem 'factory_bot_rails'
   gem 'simplecov'
   gem 'database_cleaner'
   gem 'pry'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -82,10 +82,10 @@ GEM
     erubis (2.7.0)
     eventmachine (1.2.7)
     execjs (2.7.0)
-    factory_girl (4.9.0)
+    factory_bot (4.8.2)
       activesupport (>= 3.0.0)
-    factory_girl_rails (4.9.0)
-      factory_girl (~> 4.9.0)
+    factory_bot_rails (4.8.2)
+      factory_bot (~> 4.8.2)
       railties (>= 3.0.0)
     ffi (1.10.0)
     formatador (0.2.5)
@@ -265,7 +265,7 @@ DEPENDENCIES
   capybara
   coffee-rails (~> 4.1.0)
   database_cleaner
-  factory_girl_rails
+  factory_bot_rails
   google-analytics-rails
   guard-rspec
   jbuilder (~> 2.0)

--- a/spec/factories/programmers.rb
+++ b/spec/factories/programmers.rb
@@ -1,12 +1,12 @@
-FactoryGirl.define do
+FactoryBot.define do
   factory :programmer do
-    name 'Alan Turing' 
-    home_country 'United Kingdom' 
-    birth_date '1912-06-23' 
-    death_date '1954-06-07' 
-    image 'https://upload.wikimedia.org/wikipedia/commons/a/a1/Alan_Turing_Aged_16.jpg' 
-    wikipedia_page 'https://en.wikipedia.org/wiki/Alan_Turing' 
-    quote 'A computer would deserve to be called intelligent if it could deceive a human into believing that it was human.' 
+    name 'Alan Turing'
+    home_country 'United Kingdom'
+    birth_date '1912-06-23'
+    death_date '1954-06-07'
+    image 'https://upload.wikimedia.org/wikipedia/commons/a/a1/Alan_Turing_Aged_16.jpg'
+    wikipedia_page 'https://en.wikipedia.org/wiki/Alan_Turing'
+    quote 'A computer would deserve to be called intelligent if it could deceive a human into believing that it was human.'
     claim_to_fame 'The Turing machine, breaking the Enigma code'
   end
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -25,7 +25,7 @@ require 'rspec/rails'
 ActiveRecord::Migration.maintain_test_schema!
 
 RSpec.configure do |config|
-  config.include FactoryGirl::Syntax::Methods
+  config.include FactoryBot::Syntax::Methods
 
   config.before(:suite) do
     DatabaseCleaner.clean_with(:truncation)

--- a/spec/views/partials_spec.rb
+++ b/spec/views/partials_spec.rb
@@ -4,13 +4,13 @@ require 'spec_helper'
 describe "the navbar partial" do
   it "renders the navbar correctly" do
     render "layouts/navbar"
-   
+
     expect(response).to include('Programmers We L<span class="glyphicon glyphicon-heart"></span>ve')
   end
 end
 
 describe "the programmer partial" do
-  let(:programmer) { FactoryGirl.create(:programmer) }
+  let(:programmer) { FactoryBot.create(:programmer) }
 
   before do
     render "programmers/programmer", :programmer => programmer
@@ -40,15 +40,15 @@ end
 
 # BONUS: Create a partial that renders a single attribute of a programmer
 xdescribe "the attribute partial" do
-  let(:programmer) { FactoryGirl.create(:programmer) }
+  let(:programmer) { FactoryBot.create(:programmer) }
 
   it "renders any attribute of the programmer" do
       view.lookup_context.prefixes = %w[programmers]
-      assign(:programmer, programmer)  
+      assign(:programmer, programmer)
       render :template => "programmers/show.html.erb"
       expect(response).not_to include("programmer.send(attribute)")
       expect(response).not_to include("programmer.home_country")
-    
+
   end
 
 end


### PR DESCRIPTION
The Problem:
The `factory_girl_rails` gem has been deprecated, and replaced by `factory_bot_rails`.  Some further explanation from the maintainers can be found [here](https://github.com/thoughtbot/factory_bot/issues/1053).  Using the deprecated gem causes a bunch of annoying deprecation warnings whenever you do anything with the `rails` executable, even if it's not touching the part of the code that uses `FactoryGirl`.

The Solution:
Followed the upgrade instructions [here](https://github.com/thoughtbot/factory_bot/blob/v4.9.0/UPGRADE_FROM_FACTORY_GIRL.md).  Pretty simple find and replace.  (My editor also made some whitespace changes.)

Closes #17 

#staff

